### PR TITLE
Updated checkResponse method to handle different error data structures

### DIFF
--- a/src/Provider/Bitbucket.php
+++ b/src/Provider/Bitbucket.php
@@ -66,8 +66,33 @@ class Bitbucket extends AbstractProvider
     protected function checkResponse(ResponseInterface $response, $data)
     {
         if (isset($data['error'])) {
-            throw new IdentityProviderException($data['error_description'], $response->getStatusCode(), $response);
+            if (is_array($data['error'])) {
+                $this->_throwException(
+                    $data['error']['message'],
+                    $response->getStatusCode(),
+                    $response
+                );
+            }
+           $this->_throwException(
+               $data['error_description'],
+               $response->getStatusCode(),
+               $response
+           );
         }
+    }
+
+    /**
+     * Abstracted method to throw exceptions
+     *
+     * @param $message
+     * @param $statusCode
+     * @param $response
+     *
+     * @throws IdentityProviderException
+     */
+    protected function _throwException($message, $statusCode, $response)
+    {
+        throw new IdentityProviderException($message, $statusCode, $response);
     }
 
     /**

--- a/src/Provider/Bitbucket.php
+++ b/src/Provider/Bitbucket.php
@@ -67,17 +67,17 @@ class Bitbucket extends AbstractProvider
     {
         if (isset($data['error'])) {
             if (is_array($data['error'])) {
-                $this->_throwException(
+                $this->throwException(
                     $data['error']['message'],
                     $response->getStatusCode(),
                     $response
                 );
             }
-           $this->_throwException(
+            $this->throwException(
                $data['error_description'],
                $response->getStatusCode(),
                $response
-           );
+            );
         }
     }
 
@@ -90,7 +90,7 @@ class Bitbucket extends AbstractProvider
      *
      * @throws IdentityProviderException
      */
-    protected function _throwException($message, $statusCode, $response)
+    protected function throwException($message, $statusCode, $response)
     {
         throw new IdentityProviderException($message, $statusCode, $response);
     }

--- a/src/Provider/Bitbucket.php
+++ b/src/Provider/Bitbucket.php
@@ -74,9 +74,9 @@ class Bitbucket extends AbstractProvider
                 );
             }
             $this->throwException(
-               $data['error_description'],
-               $response->getStatusCode(),
-               $response
+                $data['error_description'],
+                $response->getStatusCode(),
+                $response
             );
         }
     }


### PR DESCRIPTION
I noticed sometimes the $data array getting parsed to the checkResponse method sometimes has a different structure so have added in the necessary checks to be able to handle the difference and abstracted the throw exception call.
