### PR TITLE
Use space character as scope separator

### DIFF
--- a/src/Provider/Bitbucket.php
+++ b/src/Provider/Bitbucket.php
@@ -58,6 +58,17 @@ class Bitbucket extends AbstractProvider
     }
 
     /**
+     * Returns the string that should be used to separate scopes when building
+     * the URL for requesting an access token.
+     *
+     * @return string Scope separator, defaults to ' '
+     */
+    protected function getScopeSeparator()
+    {
+        return ' ';
+    }
+
+    /**
      * Check a provider response for errors.
      *
      * @throws IdentityProviderException

--- a/test/src/Provider/BitbucketTest.php
+++ b/test/src/Provider/BitbucketTest.php
@@ -42,7 +42,7 @@ class BitbucketTest extends \PHPUnit_Framework_TestCase
 
     public function testScopes()
     {
-        $scopeSeparator = ',';
+        $scopeSeparator = ' ';
         $options = ['scope' => [uniqid(), uniqid()]];
         $query = ['scope' => implode($scopeSeparator, $options['scope'])];
         $url = $this->provider->getAuthorizationUrl($options);


### PR DESCRIPTION
The default scope separator in oauth2-client is the comma (,), but Bitbucket seems to use spaces.

I don't have any links/official docs to support this claim, but commas didn't work for me while spaces did work. 